### PR TITLE
Optional data truncating and Zoom & Pan QoL changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ var data = [];
 var clicks = [];
 var chart, xScale, yScale, xAxis, yAxis, axisScale;
 var mouseX;
+var prevKeep = '0';
 var timerBar, animating = false;
 var sock;
 var fmt = d3.format("0,000");
@@ -17,6 +18,7 @@ function init() {
 	$(window).on('resize', resize);
 	$('#chart').on('mousewheel', mouseWheel)
 			   .on('mousedown', mouseDown);
+	$('#keep').on('change', keepChanged);
 	Stats.start = moment().format("YYYY-MM-DD HH:mm:ss");
 	resize();
 }
@@ -52,6 +54,17 @@ function resize() {
 	else {
 		$('.footer.twitter, .footer.web').show();
 	}
+}
+
+//Triggered when the value is changed, and enter is pressed or input loses focus
+function keepChanged(e) {
+	var i = parseInt($('#keep').val()) || 0;
+	if (i < 0) { i = 0; }
+	
+	//Set the new value or restore old if canceled
+	if (Comms.setKeep(i)) { $('#keep').val(i); }
+	else { $('#keep').val(prevKeep); }
+	prevKeep = $('#keep').val();
 }
 
 //Mouse functions

--- a/comms.js
+++ b/comms.js
@@ -3,6 +3,9 @@ var Comms = (function() {
 	var sock = new WebSocket('wss://wss.redditmedia.com/thebutton?h=0ac3a25d899813fdf6ce06b0e80b7ef56a850bce&e=1428493002');
 	sock.onmessage = tick;
 
+	self.keep = 0; //Amount of data points to keep, 0 means an infinite amount
+	self.newClick = false;
+	
 	function tick(evt) {
 		// {"type": "ticking", "payload": {"participants_text": "585,177", "tick_mac": "362a88a8ae0a89c909395f587e329992c656b4d8", "seconds_left": 59.0, "now_str": "2015-04-04-23-44-42"}}
 		var packet = JSON.parse(evt.data);
@@ -15,9 +18,18 @@ var Comms = (function() {
 
 		if (data.length > 0 && packet.payload.seconds_left >= _.last(data).seconds_left) {
 			_.last(data).is_click = true;
-		}
+			
+			//Update number of clicks when a new one is added
+			updateClicks();
+			
+			//Truncate data if the limit is reached
+			if (self.keep != 0 && clicks.length > self.keep) {
+				truncateData(self.keep);
+			}
+			
+			self.newClick = true;
+		} else { self.newClick = false; }
 		data.push(packet.payload);
-		$('#resets').text(fmt(clicks.length));
 		Stats.ticks = fmt(data.length);
 		Stats.participants = packet.payload.participants_text;
 
@@ -26,5 +38,30 @@ var Comms = (function() {
 		Stats.render();
 	}
 
+	self.setKeep = function(val) {
+		if (val < clicks.length && val != 0) {
+			//If the amount of data to keep is less than the amount of data stored, warn the user
+			if (confirm("Warning, this will irreversibly truncate your current data.")) {
+				self.keep = val;
+				truncateData(self.keep);
+				Chart.render(data);
+				return true;
+			}
+			return false;
+		}
+		self.keep = val;
+		return true;
+	}
+	
+	function updateClicks() {
+		clicks = _.filter(data, 'is_click');
+	}
+	
+	function truncateData(num) {
+		var begin = clicks[clicks.length - num];
+		data = data.slice(data.indexOf(begin));
+		updateClicks();
+	}
+	
 	return self;
 }())

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 			<div>Participants: <span id="participants"></span></div>
 			<div>Resets: <span id="resets"></span></div>
 			<div>Ticks: <span id="ticks"></span></div>
+			<div>Keep: <input type="text" id="keep" value="0" maxlength="7"></div>
 		</div>
 		<div id="timer">
 		</div>

--- a/style.css
+++ b/style.css
@@ -42,6 +42,11 @@ html, body {
 	padding: 0;
 }
 
+#keep {
+	height: 18px;
+	width: 50px;
+}
+
 .github {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Added an optional field to set a maximum amount of data points to keep.
For people who want to leave the site open but not end up with 10k data
points (it can lag up the graph a lot, and if you want to remove some you have to start at 0 again).
Demo: https://gfycat.com/WarmBeautifulAnura
- Keeps X data points + the timer bar
- Set to 0 to disable truncating (disabled by default)

Zoom & Pan QoL:
- New clicks will no longer compress the current zoomed section's bars
- Viewport will follow the zoomed section even if it moves due to data
  truncating
