### PR TITLE
Fix insecure warning when served with HTTPS

### DIFF
--- a/comms.js
+++ b/comms.js
@@ -24,7 +24,7 @@ var Comms = (function() {
 		sock.onmessage = tick;
 	};
 	// Use CORS proxy by lezed1 to get the Reddit homepage!
-	redditRequester.open("get", "http://cors-unblocker.herokuapp.com/get?url=https%3A%2F%2Fwww.reddit.com%2Fr%2Fthebutton", true);
+	redditRequester.open("get", "//cors-unblocker.herokuapp.com/get?url=https%3A%2F%2Fwww.reddit.com%2Fr%2Fthebutton", true);
 	redditRequester.send();
 
 	function tick(evt) {

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
 
 
-	<link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.css" rel="stylesheet">
+	<link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.css" rel="stylesheet">
 	<link href="style.css" rel="stylesheet">
 <body>
 	<div id="loading-indicator">
@@ -28,20 +28,20 @@
 		<div id="timer">
 		</div>
 		<div class="footer twitter">
-			Follow <a href="http://twitter.com/jamesrom">@jamesrom</a>
+			Follow <a href="https://twitter.com/jamesrom">@jamesrom</a>
 		</div>
 		<div class="footer email">
-			Fork on <a href="http://github.com/jamesrom/jamesrom.github.io/">GitHub</a>. Thanks to <a href="http://github.com/jamesrom/jamesrom.github.io/graphs/contributors">contributors</a>
+			Fork on <a href="https://github.com/jamesrom/jamesrom.github.io/">GitHub</a>. Thanks to <a href="https://github.com/jamesrom/jamesrom.github.io/graphs/contributors">contributors</a>
 		</div>
 		<div class="footer web">
 			Visit <a href="http://jamesromeril.com/">jamesromeril.com</a>
 		</div>
 	</div>
 	
-	<script src="http://code.jquery.com/jquery-1.11.2.min.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.6.0/lodash.min.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.9.0/moment.min.js"></script>
+	<script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.6.0/lodash.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.9.0/moment.min.js"></script>
 
 	<!-- Used to get valid "mousewheel" events in Firefox -->
 	<script src="jQuery_mousewheel_3_1_12.js"></script>


### PR DESCRIPTION
All explicit uses of "http://" have been changed to
"https://", "//" or left untouched prefering each in that order.

The only "http://" left is the link to your website. All links to other sites are "https://" and recourses to not require a specific protocol by using "//".