### PR TITLE
Make mouseover tips stay within window are, closes #35

### DIFF
--- a/d3-tip.js
+++ b/d3-tip.js
@@ -59,8 +59,8 @@
       while(i--) nodel.classed(directions[i], false)
       coords = direction_callbacks.get(dir).apply(this)
       nodel.classed(dir, true).style({
-        top: Math.max((coords.top +  poffset[0]) + scrollTop, 0) + 'px',
-        left: (coords.left + poffset[1]) + scrollLeft + 'px'
+        top: Math.max((coords.top +  poffset[0]) + scrollTop, -12) + 'px',
+        left: Math.max((coords.left + poffset[1]) + scrollLeft, -60) + 'px'
       })
 
       return tip

--- a/d3-tip.js
+++ b/d3-tip.js
@@ -59,7 +59,7 @@
       while(i--) nodel.classed(directions[i], false)
       coords = direction_callbacks.get(dir).apply(this)
       nodel.classed(dir, true).style({
-        top: (coords.top +  poffset[0]) + scrollTop + 'px',
+        top: Math.max((coords.top +  poffset[0]) + scrollTop, 0) + 'px',
         left: (coords.left + poffset[1]) + scrollLeft + 'px'
       })
 


### PR DESCRIPTION
Makes the d3_tips that appear on mouseover stay within the window area enough that their data can always be read.